### PR TITLE
add RECORD_REPLAY_NODE_DIRECTORY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ Run an executable command with `$PATH` updated so that all node scripts will use
 `replay-node --update`
 
 Ensure the replay version of node is downloaded/updated.
+
+### Supported environment variables:
+
+- RECORD_REPLAY_DIRECTORY (defaults to $HOME/.replay)
+- RECORD_REPLAY_NODE_DIRECTORY (defaults to $RECORD_REPLAY_DIRECTORY/node)
+  Allows to specify a folder in which the `node` binary is to be found.
+  Specifying this environment variable means you take control over that binary - the script will only use it, but never update it.
+- RECORD_REPLAY_DRIVER
+  Allows you to specify the path to the `recordreplay.so` driver library.
+  Specifying this environment variable means you take control over that library file - the script will use it, but never update it.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Ensure the replay version of node is downloaded/updated.
 
 - RECORD_REPLAY_DIRECTORY (defaults to $HOME/.replay)
 - RECORD_REPLAY_NODE_DIRECTORY (defaults to $RECORD_REPLAY_DIRECTORY/node)
-  Allows to specify a folder in which the `node` binary is to be found.
-  Specifying this environment variable means you take control over that binary - the script will only use it, but never update it.
+  Allows to specify a folder in which the replay-patched `node` binary is to be found.
 - RECORD_REPLAY_DRIVER
   Allows you to specify the path to the `recordreplay.so` driver library.
-  Specifying this environment variable means you take control over that library file - the script will use it, but never update it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/replay-node-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "CLI tool for creating recordings using the replay version of node",
   "bin": {
     "replay-node": "bin/replay-node"

--- a/src/bin.js
+++ b/src/bin.js
@@ -76,30 +76,23 @@ async function updateNode() {
     fs.mkdirSync(getDirectory());
   }
 
-  if (process.env.RECORD_REPLAY_NODE_DIRECTORY) {
-    if (!fs.existsSync(`${process.env.RECORD_REPLAY_NODE_DIRECTORY}/node`)) {
-      throw new Error(
-        `Environment variable for a manually managed "RECORD_REPLAY_NODE_DIRECTORY" was specified, but no "node" binary could be found there. Exiting`
-      );
-    }
-    if (gNeedUpdate) {
-      throw new Error(`Manually managed binaries (as specified per "RECORD_REPLAY_NODE_DIRECTORY" will not be updated by this cli.)`);
-    }
-    // manually managed binaries should not be updated by this script
-    return;
-  }
-
-  if (!fs.existsSync(`${getDirectory()}/node`)) {
-    fs.mkdirSync(`${getDirectory()}/node`);
+  if (!fs.existsSync(`${getNodeDirectory()}`)) {
+    fs.mkdirSync(`${getNodeDirectory()}`);
   }
 
   const file = `${currentPlatform()}-replay-node`;
 
-  const pathNode = `${getDirectory()}/node/node`;
-  const pathJSON = `${getDirectory()}/node/node.json`;
+  const pathNode = `${getNodeDirectory()}/node`;
+  const pathJSON = `${getNodeDirectory()}/node.json`;
 
   if (!gNeedUpdate && fs.existsSync(pathNode)) {
     return;
+  }
+
+  if (fs.existsSync(pathNode) !== fs.existsSync(pathJSON)) {
+    throw new Error(`Only one of the two files "node" and "node.json" exists in ${getNodeDirectory()}. 
+This indicates that those files are not managed by this update script, but by you manually - this script will now exit. 
+If you want this script to take over, remove the remaining file and restart the update process.`);
   }
 
   let jsonContents;


### PR DESCRIPTION
As discussed [in Discord](https://discord.com/channels/779097926135054346/779097926135054350/962048222916902963) with ryanjduffy, this adds a `RECORD_REPLAY_NODE_DIRECTORY` environment variable to manually specify a search part for the replay-node `node` binary that can be unmanaged by the download/update script.